### PR TITLE
Styling and code updates

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -35,6 +35,17 @@ export default class About extends React.Component {
     });
   }
 
+  scrollLink(ref, content) {
+    return <button type="button" className="anchor" onClick={() => this.scrollto(ref)}>{content}</button>;
+  }
+
+  footnoteLink(ref, returnRef, content) {
+    return <button type="button" className="footnoteLink" onClick={() => this.scrollto(ref)} ref={returnRef} ><sup>{content}</sup></button>;
+  }
+
+  externalLink(ref, content) {
+    return <a target='_blank' rel="noopener noreferrer" href={ref}>{content}</a>;
+  }
 
   render() {
     return (
@@ -45,40 +56,43 @@ export default class About extends React.Component {
           src="img/curtain-side-full.png"
           className="curtain-side"
           draggable="false"
+          alt=""
         />
         <img
           src="img/curtain-bg-full.jpg"
           className="curtain-bg"
           draggable="false"
+          alt=""
         />
         <div className="about" ref={this.aboutPageContent}>
-          <img src="img/about.png" className="secondary-header" draggable="false" />
+          <img src="img/about.png" className="secondary-header" draggable="false" alt="About" />
           <img
             src="img/About/Zizi banner.jpg"
             className="banner"
             draggable="false"
+            alt=""
           />
           <ul className="anchors">
             <li>
-              <a onClick={() => this.scrollto(this.team)}>The Team</a>
+            {this.scrollLink(this.team, "The Team")}
             </li>
             <li>
-              <a onClick={() => this.scrollto(this.intro)}>Intro</a>
+              {this.scrollLink(this.intro, "Intro")}
             </li>
             <li>
-              <a onClick={() => this.scrollto(this.process)}>The Process</a>
+              {this.scrollLink(this.process, "The Process")}
             </li>
             <li>
-              <a onClick={() => this.scrollto(this.footnotes)}>Footnotes</a>
+              {this.scrollLink(this.footnotes, "Footnotes")}
             </li>
             <li>
-              <a onClick={() => this.scrollto(this.aboutArtist)}>About the Artist</a>
+              {this.scrollLink(this.aboutArtist, "About the Artist")}
             </li>
             <li>
-              <a onClick={() => this.scrollto(this.aboutProject)}>About the Zizi Project</a>
+              {this.scrollLink(this.aboutProject, "About the Zizi Project")}
             </li>
             <li>
-              <a onClick={() => this.scrollto(this.other)}>The Zizi Project: Other Works</a>
+              {this.scrollLink(this.other, "The Zizi Project: Other Works")}
             </li>
           </ul>
 
@@ -86,23 +100,23 @@ export default class About extends React.Component {
           <h2 ref={this.team}>Team</h2>
           <ul>
             <li>
-              <b><a target='_blank' href="https://www.jakeelwes.com/">Jake Elwes</a></b> - Artist
+              <b>{this.externalLink("https://www.jakeelwes.com/", "Jake Elwes")}</b> - Artist
           </li>
             <li>
-              <b><a target='_blank' href="https://www.instagram.com/methedragqueen">Me</a></b> - Performance &amp; Casting Director
+              <b>{this.externalLink("https://www.instagram.com/methedragqueen", "Me")}</b> - Performance &amp; Casting Director
           </li>
             <li>
-              <b><a target='_blank' href="https://alxhill.com/">Alexander Hill</a></b> - Web &amp; Development
+              <b>{this.externalLink("https://alxhill.com/", "Alexander Hill")}</b> - Web &amp; Development
           </li>
             <li>
-              <b><a target='_blank' href="https://www.tobyelwes.com/">Toby Elwes</a></b> - Camera &amp; Lighting
+              <b>{this.externalLink("https://www.tobyelwes.com/", "Toby Elwes")}</b> - Camera &amp; Lighting
           </li>
             <li>
-              <b><a target='_blank' href="https://soundcloud.com/breakaleeds">Charlie Baker</a></b> - Sound Mixing
+              <b>{this.externalLink("https://soundcloud.com/breakaleeds", "Charlie Baker")}</b> - Sound Mixing
           </li>
           </ul>
           <small>
-            <p style={{ textAlign: "center", marginTop: "3rem" }}><i>In Collaboration with the <b><a target='_blank' href="https://efi.ed.ac.uk/activity-and-partners/experiential-ai">Edinburgh Futures Institute</a></b></i></p>
+            <p style={{ textAlign: "center", marginTop: "3rem" }}><i>In Collaboration with the <b>{this.externalLink("https://efi.ed.ac.uk/activity-and-partners/experiential-ai", "Edinburgh Futures Institute")}</b></i></p>
             <ul>
               <li>
                 <b>Drew Hemment</b> - Project Director &amp; Curator
@@ -115,7 +129,7 @@ export default class About extends React.Component {
           </li>
             </ul>
             <br />
-            <p>The Zizi Show is part of <a target='_blank' href="https://newreal.cc/">The New Real</a> by <a target='_blank' href="https://efi.ed.ac.uk/activity-and-partners/experiential-ai">Edinburgh Futures Institute</a> at <a target='_blank' href="https://www.eif.co.uk/whats-on/2020/the-new-real">Edinburgh International Festival.</a></p>
+            <p>The Zizi Show is part of {this.externalLink("https://newreal.cc/", "The New Real")} by {this.externalLink("https://efi.ed.ac.uk/activity-and-partners/experiential-ai", "Edinburgh Futures Institute")} at {this.externalLink("https://www.eif.co.uk/whats-on/2020/the-new-real", "Edinburgh International Festival")}.</p>
           </small>
           <hr />
           <i ref={this.intro}>
@@ -137,42 +151,34 @@ export default class About extends React.Component {
 
           <p>
             Machine learning – teaching computers to learn from data – and specifically deepfake technology, has been used to construct all the videos you see on this website. To produce a deepfake, you start by training a neural network
-          <a onClick={() => this.scrollto(this.fn1)} ref={this.rfn1}><sup>
-              1
-          </sup></a>{" "}
-          on a dataset of images.
+          {this.footnoteLink(this.fn1, this.rfn1, "1")} on a dataset of images.
         </p>
           <p>
             This dataset contains the original images (video frames) of the real-life person, as well as a graphic tracking the position of their skeleton, facial features, and silhouette.
         </p>
           <p>
             Creating deepfakes begins with training a neural network to try to recreate the original image of this person based on just their skeleton tracking (illustrated below). The neural network aims to get as close as possible to the original and does this by being given an accuracy score.
-            <a onClick={() => this.scrollto(this.fn2)} ref={this.rfn2}><sup>
-              2
-          </sup></a>{" "}
-          Once it has learnt to do this it can then start producing deepfakes.
+            {this.footnoteLink(this.fn2, this.rfn2, "2")} Once it has learnt to do this it can then start producing deepfakes.
         </p>
           <p>
-            Below, you can see the iterative training process of a neural network as it learns how to create images of the drag queen an burlesque artist <a target='_blank' href="https://www.instagram.com/lillysnatch/">Lilly SnatchDragon</a>:
+            Below, you can see the iterative training process of a neural network as it learns how to create images of the drag queen an burlesque artist {this.externalLink("https://www.instagram.com/lillysnatch/", "Lilly SnatchDragon")}:
         </p>
 
-          <img className="diagram" src="img/About/diagram.gif" draggable="false" />
+          <img className="diagram" src="img/About/diagram.gif" draggable="false" alt="Training process"/>
 
           <p>
-            Using machine learning, this process iterates and improves until it can create new, fake faces which are indistinguishable from the real. For Zizi, the method I use is called <a target='_blank' href="https://arxiv.org/abs/1808.06601"></a>Video-to-Video Synthesis.
-            <a onClick={() => this.scrollto(this.fn3)} ref={this.rfn3}><sup>
-              3
-          </sup></a>
+            Using machine learning, this process iterates and improves until it can create new, fake faces which are indistinguishable from the real. For Zizi, the method I use is called {this.externalLink("https://arxiv.org/abs/1808.06601", "Video-to-Video Synthesis")}.
+            {this.footnoteLink(this.fn3, this.rfn3, "3")}
           </p>
           <p>
             Once the neural network has been training for, let's say, three days, it is ready to be fed new movements. Anyone can now control the deepfake body by running skeleton tracking on a new video and then feeding these into the neural network.
         </p>
           <p>
-            These visuals below show how new deepfake images of <a target='_blank' href="https://www.instagram.com/lillysnatch/">Lilly SnatchDragon</a> can be generated from the trained neural network (here with her movement controlled by <a target='_blank' href="https://www.instagram.com/methedragqueen">Me (the Drag Queen)</a>.
+            These visuals below show how new deepfake images of {this.externalLink("https://www.instagram.com/lillysnatch/", "Lilly SnatchDragon")} can be generated from the trained neural network (here with her movement controlled by {this.externalLink("https://www.instagram.com/methedragqueen", "Me (the Drag Queen)")}.
         </p>
 
-          <img className="diagram" src="img/About/diagram-gen-close-small.gif" draggable="false" />
-          <img className="diagram" src="img/About/diagram-gen-full-small.gif" draggable="false" />
+          <img className="diagram" src="img/About/diagram-gen-close-small.gif" draggable="false" alt="Closeup deepfake" />
+          <img className="diagram" src="img/About/diagram-gen-full-small.gif" draggable="false" alt="Full view deepfake" />
           <p>
             This process was repeated to create deepfakes of all 13 of our wonderful, diverse drag cast.
         </p>
@@ -181,12 +187,7 @@ export default class About extends React.Component {
         </p>
           <p>
             Facial recognition algorithms (and deepfake technology) currently have difficulty recognising trans, queer and other marginalised identities, because they are often made by cis white people.
-            <a onClick={() => this.scrollto(this.fn4)} ref={this.rfn4}><sup>
-              4
-          </sup></a>
-            <a onClick={() => this.scrollto(this.fn5)} ref={this.rfn5}><sup>
-              5
-          </sup></a>
+            {this.footnoteLink(this.fn4, this.rfn4, "4")}, {this.footnoteLink(this.fn5, this.rfn5, "5")}
           </p>
           <p>
             The project asks whether making deepfakes using queer identities becomes a means of assimilation or inclusivity… or more a techno-activist method of dirtying and obfuscating the systems used to collect data on us.
@@ -199,7 +200,7 @@ export default class About extends React.Component {
           <h2 ref={this.footnotes}>Footnotes</h2>
           <p>
             <small className="footnote" ref={this.fn1}>
-              1. For more information see <a target='_blank' href="https://deepai.org/machine-learning-glossary-and-terms/neural-network">DeepAI.org glossary - 'neural network'. </a>
+              1. For more information see {this.externalLink("https://deepai.org/machine-learning-glossary-and-terms/neural-network", "DeepAI.org glossary - 'neural network'")}.
             </small>
             <Return onClick={() => this.scrollto(this.rfn1)}/>
           </p>
@@ -212,23 +213,21 @@ export default class About extends React.Component {
           </p>
           <p>
             <small className="footnote" ref={this.fn3}>
-              3. <a target='_blank' href="https://arxiv.org/abs/1808.06601">Video-to-Video Synthesis</a> is a conditional generative adversarial
+              3. {this.externalLink("https://arxiv.org/abs/1808.06601", "Video-to-Video Synthesis")} is a conditional generative adversarial
             network (cGAN) developed by Wang et al. (Nvidia &amp; MIT), NeurIPS,
-            2018. It uses <a target='_blank' href="https://arxiv.org/abs/1812.08008">OpenPose</a> (2018) for skeleton tracking and <a target='_blank' href="https://arxiv.org/abs/1802.00434">DensePose</a> (2018) for silhouette estimation. This technique also uses <a target='_blank' href="https://arxiv.org/abs/1612.01925">Flownet</a> (2016) to take into account the motion in the video.
+            2018. It uses {this.externalLink("https://arxiv.org/abs/1812.08008", "OpenPose")} (2018) for skeleton tracking and {this.externalLink("https://arxiv.org/abs/1802.00434", "DensePose")} (2018) for silhouette estimation. This technique also uses {this.externalLink("https://arxiv.org/abs/1612.01925", "Flownet")} (2016) to take into account the motion in the video.
           </small>
           <Return onClick={() => this.scrollto(this.rfn3)}/>
           </p>
           <p>
             <small className="footnote" ref={this.fn4}>
-              4. <a target='_blank' href="https://www.researchgate.net/publication/324670607_Gender_Recognition_or_Gender_Reductionism_The_Social_Implications_of_Embedded_Gender_Recognition_Systems"> Gender recognition or gender reductionism? The social implications
-            of embedded gender recognition systems.</a> Hamidi, F., Scheuerman, M.K. and Branham, S.M. (2018).
+              4. {this.externalLink("https://www.researchgate.net/publication/324670607_Gender_Recognition_or_Gender_Reductionism_The_Social_Implications_of_Embedded_Gender_Recognition_Systems", "Gender recognition or gender reductionism? The social implications of embedded gender recognition systems")}, Hamidi, F., Scheuerman, M.K. and Branham, S.M. (2018).
           </small>
           <Return onClick={() => this.scrollto(this.rfn4)}/>
           </p>
           <p>
             <small className="footnote" ref={this.fn5}>
-              5. <a target='_blank' href="https://www.excavating.ai/">Excavating AI: The Politics of Images in Machine Learning
-            Training Sets</a>, Kate Crawford and Trevor Paglen. 
+              5. {this.externalLink("https://www.excavating.ai/", "Excavating AI: The Politics of Images in Machine Learning Training Sets")}, Kate Crawford and Trevor Paglen.
           </small>
           <Return onClick={() => this.scrollto(this.rfn5)}/>
           </p>
@@ -236,7 +235,7 @@ export default class About extends React.Component {
           <hr />
           <h2 ref={this.aboutArtist}>About the Artist</h2>
           <p>
-            <a target='_blank' href="https://www.jakeelwes.com/">Jake Elwes</a> is an artist living and working in London. His recent works have looked at machine learning and artificial intelligence research, exploring the code, philosophy and ethics behind it. In his art Jake engages with both the history and tropes of fine art and the possibilities and consequences of digital technology. He graduated with a BA in Fine Art from the Slade School of Fine Art (UCL), London in 2017.
+            {this.externalLink("https://www.jakeelwes.com/", "Jake Elwes")} is an artist living and working in London. His recent works have looked at machine learning and artificial intelligence research, exploring the code, philosophy and ethics behind it. In his art Jake engages with both the history and tropes of fine art and the possibilities and consequences of digital technology. He graduated with a BA in Fine Art from the Slade School of Fine Art (UCL), London in 2017.
         </p><p>
             Jake's work has been exhibited in museums and galleries internationally, including the ZKM, Karlsruhe, Germany; TANK Museum, Shanghai; Today Art Museum, Beijing; CyFest, Venice; Edinburgh Futures Institute, UK; Zabludowicz Collection, London; Frankfurter Kunstverein, Germany; New Contemporaries 2017, UK; Ars Electronica 2017, Austria; Victoria and Albert Museum, London; LABoral Centro, Spain; Nature Morte, Delhi, India, Centre for the Future of Intelligence, UK. He has also been featured on BBC4.
         </p>
@@ -249,30 +248,32 @@ export default class About extends React.Component {
             The Zizi Project (2019 - ongoing) is a collection of works by Jake Elwes exploring the intersection of Artificial Intelligence (A.I.) and drag performance. Drag challenges gender and explores otherness, while A.I. is often mystified as a concept and tool, and is complicit in reproducing social bias. Zizi combines these themes through a deepfake, synthesised drag identity created using machine learning. The project explores what AI can teach us about drag, and what drag can teach us about A.I.
         </p>
           <p>
-            Zizi is the focus of a partnership between Jake and the <a target='_blank' href="https://efi.ed.ac.uk/activity-and-partners/experiential-ai">Experiential AI</a> research group  at Edinburgh Futures Institute, part of the University of Edinburgh. The Experiential AI group aims to support the creation of artistic works using machine learning algorithms and robotics, and to inspire new concepts and paradigms on ethical and responsible AI.
+            Zizi is the focus of a partnership between Jake and the {this.externalLink("https://efi.ed.ac.uk/activity-and-partners/experiential-ai", "Experiential AI")} research group  at Edinburgh Futures Institute, part of the University of Edinburgh. The Experiential AI group aims to support the creation of artistic works using machine learning algorithms and robotics, and to inspire new concepts and paradigms on ethical and responsible AI.
         </p>
           <p>
-            The Zizi Show is commissioned and produced by Edinburgh Futures Institute as a part of <a target='_blank' href="https://www.newreal.cc">The New Real</a> and presented at  <a target='_blank' href="https://www.eif.co.uk/whats-on/2020/the-new-real">Edinburgh International Festival</a>. Supported by the University of Edinburgh, Creative Scotland, Creative Informatics, and the Data-Driven Innovation programme of the South East Scotland City and Region Deal.
+            The Zizi Show is commissioned and produced by Edinburgh Futures Institute as a part of {this.externalLink("https://www.newreal.cc", "The New Real")} and presented at {this.externalLink("https://www.eif.co.uk/whats-on/2020/the-new-real", "Edinburgh International Festival")}. Supported by the University of Edinburgh, Creative Scotland, Creative Informatics, and the Data-Driven Innovation programme of the South East Scotland City and Region Deal.
         </p>
           <hr />
           <h2 ref={this.other}>'Zizi &amp; Me' 2020</h2>
           <p>
-            <small><a target='_blank' href="https://www.jakeelwes.com/project-zizi-and-me.html">‘Zizi &amp; Me’</a> is a double act between drag queen Me, and a deep fake (A.I.) clone of Me. We trained a neural network1 on filmed footage. This network learnt to construct a virtual body that can be controlled by feeding it new reference movements. Through drag performance, this artwork aims to use cabaret and musical theatre to challenge narratives surrounding A.I. and society.</small>
+            <small>{this.externalLink("https://www.jakeelwes.com/project-zizi-and-me.html", "‘Zizi & Me’")} is a double act between drag queen Me, and a deep fake (A.I.) clone of Me. We trained a neural network1 on filmed footage. This network learnt to construct a virtual body that can be controlled by feeding it new reference movements. Through drag performance, this artwork aims to use cabaret and musical theatre to challenge narratives surrounding A.I. and society.</small>
           </p>
           <iframe
             width="100%"
             height="315"
             src="https://www.youtube.com/embed/vtpVr5KVvnk"
+            title="'Zizi & Me' 2020"
             frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
           ></iframe>
           <h2>'Zizi: Queering the Dataset' 2019</h2>
           <p>
-            <small><a target='_blank' href="https://www.jakeelwes.com/project-zizi-2019.html">‘Zizi - Queering the Dataset’</a> aims to tackle the lack of representation and diversity in the training datasets often used by facial recognition systems. The video was made by disrupting these systems1 and re-training them with the addition of drag and gender fluid faces found online. This causes the weights inside the neural network to shift away from the normative identities it was originally trained on and into a space of queerness. ‘Zizi - Queering The Dataset’ lets us peek inside the machine learning system and visualise what the neural network has (and hasn’t) learnt. The work is a celebration of difference and ambiguity, which invites us to reflect on bias in our data driven society.</small>
+            <small>{this.externalLink("https://www.jakeelwes.com/project-zizi-2019.html", "‘Zizi - Queering the Dataset’")} aims to tackle the lack of representation and diversity in the training datasets often used by facial recognition systems. The video was made by disrupting these systems1 and re-training them with the addition of drag and gender fluid faces found online. This causes the weights inside the neural network to shift away from the normative identities it was originally trained on and into a space of queerness. ‘Zizi - Queering The Dataset’ lets us peek inside the machine learning system and visualise what the neural network has (and hasn’t) learnt. The work is a celebration of difference and ambiguity, which invites us to reflect on bias in our data driven society.</small>
           </p>
           <iframe
             src="https://player.vimeo.com/video/388245510"
+            title="'Zizi: Queering the Dataset' 2019"
             width="100%"
             height="315"
             frameBorder="0"
@@ -284,6 +285,7 @@ export default class About extends React.Component {
             width="100%"
             height="315"
             src="https://www.youtube.com/embed/QOK97wutH-s"
+            title="Talk at National Gallery X + FLUX - 2020"
             frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen

--- a/src/App.css
+++ b/src/App.css
@@ -2,136 +2,11 @@
 @import url("https://fonts.googleapis.com/css2?family=Roboto+Slab&display=swap");
 @font-face {
   font-family: "market_decoregular";
-  src: url("font/market_deco-webfont.woff2") format("woff2"), url("font/market_deco-webfont.woff") format("woff"), url("font/market_deco.ttf") format("ttf");
+  src: url("font/market_deco-webfont.woff2") format("woff2"),
+    url("font/market_deco-webfont.woff") format("woff"),
+    url("font/market_deco.ttf") format("ttf");
   font-weight: normal;
   font-style: normal;
-}
-
-/* display for mobile and tablet */
-
-@media (max-aspect-ratio: 4/5) and (orientation: portrait) {
-  html {
-    font-size: 14px;
-  }
-  body .enter img {
-    height: auto;
-    width: 90%;
-  }
-  body .enter-screen button {
-    position: absolute;
-    right: 2rem;
-  }
-  body .zizi-sidebar {
-    left: 0;
-    right: 0;
-    top: auto;
-    bottom: 0;
-    height: 30rem;
-    flex-direction: column-reverse;
-    transition: bottom 1s ease;
-  }
-  body .pickerAboutButton {
-    position: absolute;
-    top: 2rem;
-    left: 1rem;
-    height: 3rem;
-    background-color: none;
-  }
-  body .secondary-header {
-    margin-top: 1rem;
-  }
-  body .zizi-sidebar .main-sidebar {
-    width: 100%;
-  }
-  body .zizi-sidebar.closed {
-    left: 0;
-    bottom: -26rem;
-  }
-  body .zizi-sidebar .mini-sidebar {
-    flex-direction: row;
-    height: 20%;
-    /* height for safari - no idea why */
-  }
-  body .zizi-sidebar .mini-sidebar .top-buttons, body .zizi-sidebar .mini-sidebar .centered-buttons {
-    flex-direction: row;
-  }
-  body .main-bar-content {
-    flex-shrink: 0;
-    margin-top: 2rem;
-  }
-  body .zizi-sidebar .mini-sidebar .centered-buttons>a {
-    padding: 1rem 20px 1rem 20px;
-  }
-  body .close-sidebar-left {
-    width: 100%;
-    height: 1rem;
-    min-height: 1rem;
-    max-height: 1rem;
-  }
-  body .close-sidebar-left .close-button2 {
-    display: inherit;
-    padding-left: 1rem;
-  }
-  body .secondary-sidebar {
-    left: 0;
-    right: 0;
-    top: auto;
-    bottom: 0;
-    height: 30rem;
-    flex-direction: column;
-    width: 100%;
-    transition: bottom 1s ease;
-    /* background: linear-gradient( 0deg, rgba(7, 0, 2, 1) 2%, rgba(46, 1, 15, 1) 70%, rgba(46, 1, 15, 1) 100%); */
-    background: linear-gradient(0deg, rgba(7, 0, 2, 1) 2%, rgba(46, 1, 15, 0.5) 70%, rgba(46, 1, 15, 0.9) 100%);
-    backdrop-filter: blur(2px);
-  }
-  body .zizi-picker-bar {
-    background: linear-gradient(0deg, rgba(7, 0, 2, 1) 2%, rgba(46, 1, 15, 0.5) 70%, rgba(46, 1, 15, 0.9) 100%);
-    backdrop-filter: none;
-  }
-  body .secondary-sidebar .content-sidebar {
-    padding-top: 0;
-  }
-  body .secondary-sidebar.closed {
-    bottom: -35rem;
-  }
-  body #main-bar-logo {
-    order: 1;
-    height: 8rem;
-    flex-shrink: 0;
-  }
-  body .copyright {
-    order: 2;
-    margin-bottom: 1rem;
-  }
-  body .close-button2 {
-    font-size: 2.1rem;
-    padding: 1rem;
-    background-color: #520319;
-  }
-  body .about-page .about {
-    padding: 1.5rem;
-  }
-  hr {
-    margin: auto;
-  }
-  body .about-page p {
-    font-size: 1.1rem;
-  }
-  body .about-page ul {
-    padding: 0.5rem;
-  }
-}
-
-@media only screen and (min-device-width: 320px) and (max-device-width: 568px) and (orientation: landscape) {
-  body #main-bar-logo {
-    /* order: 1; */
-    height: 12rem;
-    /* flex-shrink: 0; */
-  }
-  body .main-sidebar {
-    display: block;
-  }
 }
 
 body {
@@ -148,480 +23,11 @@ button {
   color: inherit;
   border: none;
   padding: 0;
+  margin: 0;
   font: inherit;
   cursor: pointer;
   outline: inherit;
-}
-
-.enter {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  width: 100%;
-  top: 20%;
-}
-
-.enter img {
-  height: 25rem;
-}
-
-.enter img:hover {
-  -webkit-filter: drop-shadow(0px 0px 0px #800a12);
-  filter: drop-shadow(0px 0px 0px #800a12);
-}
-
-.enter-screen button {
-  position: absolute;
-  bottom: 2rem;
-  right: 6rem;
-  font-size: 1.6rem;
-  color: #ff9c84;
-  background-color: rgba(46, 1, 15, 0.5);
-  border-radius: 12px;
-  padding: 0.6rem;
-  filter: drop-shadow(20px 20px 5px #000);
-}
-
-.pickerAboutButton {
-  position: absolute;
-  bottom: 2rem;
-  left: 6rem;
-  font-size: 1.6rem;
-  color: #ff9c84;
-  background-color: rgba(46, 1, 15, 0.5);
-  border-radius: 12px;
-  padding: 0.6rem;
-  filter: drop-shadow(20px 20px 5px #000);
-}
-
-.pickerAboutButton:hover {
-  -webkit-filter: drop-shadow(0px 0px 0px #800a12);
-  filter: drop-shadow(0px 0px 0px #800a12);
-}
-
-.enter-screen button:hover {
-  filter: brightness(160%);
-}
-
-.enter-screen button svg {
-  top: 0.125em;
-  position: relative;
-}
-
-.enter-screen .password {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  top: 60%;
-  font-size: 0.9rem;
-  padding: 0.4rem;
-  text-align: center;
-  filter: brightness(40%) sepia(100%) hue-rotate(-45deg);
-}
-
-.enter-screen p {
-  margin-top: 3rem;
-}
-
-.enter-screen b {
-  font-size: 1.5rem;
-  line-height: 50px;
-}
-
-.zizi-intro-video {
-  position: absolute;
-  height: 100%;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 0;
-}
-
-.intro-video {
-  position: absolute;
-  height: 100%;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  z-index: -2;
-}
-
-h1 {
-  font-family: "market_decoregular", sans-serif;
-  padding-bottom: 1rem;
-  text-transform: uppercase;
-  font-size: 2rem;
-}
-
-.zizi-sidebar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  display: flex;
-  color: #ff9c84;
-  transition: left 1s ease;
-}
-
-.zizi-sidebar.closed {
-  left: -27rem;
-}
-
-.zizi-sidebar a:hover {
-  color: #b22d3f;
-}
-
-#main-bar-logo {
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -o-user-select: none;
-  user-select: none;
-  /* -webkit-flex: 1 0;
-  flex: 1 0; */
-}
-
-.button-sidebar {
-  background-color: #380011;
-  /* padding: 1rem; */
-  box-shadow: 0px 0px 41px 10px rgba(0, 0, 0, 0.7);
-}
-
-.mini-sidebar {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  /* z-index: 1; */
-  z-index: 1;
-}
-
-.button-sidebar .zizi-icon {
-  font-size: 2.1rem;
-  height: 2rem;
-}
-
-.mini-sidebar .centered-buttons, .mini-sidebar .top-buttons {
-  display: flex;
-  flex-direction: column;
-}
-
-.mini-sidebar .top-buttons {
-  padding: 1rem 1rem 1rem 1rem;
-  background-color: #520319;
-}
-
-.mini-sidebar .centered-buttons>a {
-  padding: 20px 1rem 20px 1rem;
-}
-
-.close-sidebar-left {
-  box-shadow: 0px 0px 41px 10px rgba(0, 0, 0, 0.7);
-  background-color: #380011;
-  width: 1rem;
-  font-size: 2.1rem;
-  z-index: 1;
-}
-
-.close-button {
-  height: 2rem;
-  font-size: 2.1rem;
-  padding: 1rem;
-  display: inline-flex;
-  background-color: #520319;
-}
-
-.close-button2 {
-  font-size: 2.1rem;
-  /* padding: 1rem 1rem 1rem 0;
-  margin-left: 1rem; */
-  padding: 1rem;
-  width: 2rem;
-  height: 2rem;
-  display: inline-flex;
-  background-color: #520319;
-}
-
-.main-sidebar {
-  width: 27rem;
-  text-align: center;
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: space-between;
-  overflow: scroll;
-  background-color: #2e010f;
-  background: linear-gradient( 0deg, rgba(7, 0, 2, 1) 2%, rgba(46, 1, 15, 0.5) 70%, rgba(46, 1, 15, 0.9) 100%);
-  /* transform: translateY(-50%); */
-  z-index: 1;
-}
-
-.main-sidebar .zizi-icon {
-  font-size: 2rem;
-  -webkit-filter: drop-shadow(0px 0px 10px #000);
-  filter: drop-shadow(0px 0px 10px #000);
-}
-
-.copyright {
-  bottom: 0px;
-  margin-bottom: 5rem;
-}
-
-.main-sidebar a.inline-link {
-  text-decoration: none;
-  color: #ffbcaf;
-}
-
-.main-sidebar a.inline-link:hover {
-  text-decoration: none;
-  color: #d63a00;
-}
-
-.main-bar-content {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-evenly;
-}
-
-.main-bar-content>div {
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-
-.main-bar-content .player-controls a {
-  margin: 0 1rem 0 1rem;
-}
-
-.main-bar-content div:after {
-  content: "";
-  width: 6rem;
-  height: 1px;
-  background-color: #ffbcaf;
-  display: block;
-  margin: 3rem auto 3rem auto;
-}
-
-.main-sidebar sub {
-  display: block;
-}
-
-.main-sidebar .now-playing p {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.zizi-sidebar .main-bar-content .sidebar-large-button {
-  font-size: 2rem;
-}
-
-.secondary-sidebar {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 30rem;
-  height: 100%;
-  background-color: #2e010f;
-  background: linear-gradient(0deg, rgba(7, 0, 2, 1) 2%, rgba(46, 1, 15, 0.5) 70%, rgba(46, 1, 15, 0.9) 100%);
-  /* background: linear-gradient( 0deg, rgba(7, 0, 2, 1) 2%, rgba(46, 1, 15, 1) 70%, rgba(46, 1, 15, 1) 100%); */
-  color: #ff9c84;
-  text-align: center;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  transition: right 1s ease;
-  z-index: 2;
-}
-
-.secondary-sidebar.closed {
-  right: -30rem;
-}
-
-.secondary-sidebar .content-sidebar {
-  overflow: scroll;
-  width: 100%;
-}
-
-.performers-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-evenly;
-  line-height: 0.2rem;
-  font-size: 1.2rem;
-  padding-left: 2rem;
-  padding-right: 2rem;
-}
-
-.performers-list .performer {
-  padding-bottom: 0.8rem;
-}
-
-.performers-list a:hover {
-  color: #ffe6d2;
-}
-
-.performers-list .info a {
-  font-size: 0.9rem;
-  text-decoration: none;
-  color: #a33122;
-}
-
-.performers-list .info a:hover {
-  color: #db2c00;
-}
-
-.bios h2 {
-  font-size: 2rem;
-  filter: drop-shadow(0px 0px 10px rgb(255, 148, 105)) drop-shadow(10px 10px 10px #000) drop-shadow(10px 10px 20px #000);
-}
-
-.bios .backbutton {
-  font-size: 1.2rem;
-  background-color: #520319;
-  padding: 0.5rem;
-  /* border-radius: 12px; */
-  filter: drop-shadow(0px 0px 20px rgba(0, 0, 0, 0.6));
-  font-family: "market_decoregular", sans-serif;
-}
-
-.bios {
-  text-align: right;
-  padding: 2rem;
-}
-
-.bios p {
-  text-align: left;
-  font-family: 'Roboto Slab', charter, Georgia, Cambria, "Times New Roman", Times, serif;
-}
-
-.bios a {
-  /* padding-top: 5rem; */
-  text-align: center;
-  font-family: 'Roboto Slab', charter, Georgia, Cambria, "Times New Roman", Times, serif;
-}
-
-.bios img {
-  width: 100%;
-  border-radius: 12px;
-  margin-bottom: 1rem;
-}
-
-.secondary-header {
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -o-user-select: none;
-  text-align: center;
-  margin-top: 2rem;
-}
-
-.secondary-sidebar .performer img {
-  height: 10rem;
-  box-shadow: 4px 4px 10px 1px rgba(0, 0, 0, 0.5);
-  margin: 0.4rem;
-}
-
-.secondary-sidebar .performer img:hover {
-  filter: sepia(100%);
-  /* filter: contrast(90%) brightness(123%) blur(2px); */
-  /* https://developer.mozilla.org/en-US/docs/Web/CSS/filter */
-}
-
-.secondary-sidebar .song img {
-  height: 4rem;
-  float: left;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -o-user-select: none;
-}
-
-.secondary-sidebar .song {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-evenly;
-  text-align: left;
-  margin-bottom: 1rem;
-  /* background-color: #38001170; */
-}
-
-.secondary-sidebar .song:hover {
-  box-shadow: 0px 0px 50px 5px rgba(0, 0, 0, 0.7);
-}
-
-.secondary-sidebar .song p {
-  height: 4rem;
-  font-size: 0.95rem;
-  padding-left: 1rem;
-  width: 270px;
-  display: table-cell;
-  vertical-align: middle;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.secondary-sidebar .song small {
-  color: rgb(180, 95, 74);
-}
-
-.secondary-sidebar .song .sname {
-  color: rgb(255, 225, 200);
-}
-
-.secondary-sidebar .song w {
-  color: rgb(250, 174, 129);
-}
-
-.secondary-sidebar .song:hover w {
-  color: #d63a00;
-}
-
-.secondary-sidebar .song a:hover {
-  color: #f5c5b3;
-}
-
-.secondary-sidebar .song .artist {
-  color: #edb49f;
-}
-
-.secondary-sidebar .song .artist:hover {
-  color: #d63a00;
-}
-
-h2 {
-  font-family: "market_decoregular", sans-serif;
-  padding-bottom: 15px;
-  text-transform: uppercase;
-  font-size: 2rem;
-  text-align: center;
-}
-
-.secondary-sidebar .about {
-  width: 100%;
-  height: 300%;
-  background-color: #000;
-  margin: 1.5rem;
-  font-family: "Lato";
-  float: left;
-  text-align: left;
-  font-size: 15px;
-  font-size: 0.85rem;
-}
-
-.secondary-sidebar .content-sidebar .about {
-  padding-top: 0px;
-}
-
-.secondary-sidebar .about p {
-  margin: 1.5rem;
-  margin-top: 0rem;
-}
-
-.secondary-sidebar .about img {
-  width: 100%;
+  text-align: inherit;
 }
 
 .curtain-bg {
@@ -629,7 +35,6 @@ h2 {
   height: 100%;
   left: 50%;
   top: 50%;
-  user-select: none;
   transform: translate(-50%, -50%);
   z-index: -4;
   transition: opacity 1s;
@@ -640,7 +45,6 @@ h2 {
   height: 101%;
   left: 50%;
   top: 50%;
-  user-select: none;
   transform: translate(-50%, -50%);
   /* mix-blend-mode: overlay; */
   z-index: -1;
@@ -651,14 +55,17 @@ h2 {
   height: 100%;
   width: 100vh;
   left: 50%;
-  right: 50%;
   overflow: hidden;
   transform: translateX(-50%);
 }
 
+.video-frame.hidden {
+  visibility: hidden;
+}
+
 .drag-video {
   height: 100%;
-  user-select: none;
+  width: 200%;
 }
 
 .drag-video.zoom {
@@ -680,51 +87,414 @@ h2 {
   z-index: -3;
 }
 
-.video-frame.hidden {
-  visibility: hidden;
-}
-
 .drag-video-wrapper {
   position: absolute;
   width: 100%;
   height: 100%;
 }
 
-/* unvisited link */
-
-a:link {
-  color: #edb49f;
-  cursor: pointer;
-}
-
-/* visited link */
-
+/* unvisited link, visited link */
+a:link,
 a:visited {
   color: #edb49f;
-  cursor: pointer;
 }
 
 /* mouse over link */
-
 a:hover {
   color: #aa272e;
-  cursor: pointer;
 }
 
 /* selected link */
-
 a:active {
   color: #fff;
-  cursor: pointer;
 }
 
-a:disabled {
-  color: #555;
+h2 {
+  font-family: "market_decoregular", sans-serif;
+  padding-bottom: 15px;
+  text-transform: uppercase;
+  font-size: 2rem;
+  text-align: center;
 }
+
+button.inline-link {
+  display: inline;
+  color: #ffbcaf;
+}
+
+button.inline-link:hover,
+button.inline-link:focus {
+  color: #d63a00;
+}
+
+.enter-screen button.enter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  width: 100%;
+  top: 20%;
+}
+
+.enter-screen button.enter img {
+  height: 25rem;
+}
+.enter-screen button.enter img:hover {
+  -webkit-filter: drop-shadow(0px 0px 0px #800a12);
+  filter: drop-shadow(0px 0px 0px #800a12);
+}
+
+.enter-screen button.skip-intro {
+  position: absolute;
+  /* height: 25rem; */
+  bottom: 2rem;
+  right: 6rem;
+  font-size: 1.6rem;
+  color: #ff9c84;
+  background-color: rgba(46, 1, 15, 0.5);
+  border-radius: 12px;
+  padding: 0.6rem;
+  filter: drop-shadow(20px 20px 5px #000);
+}
+
+.enter-screen button.skip-intro:hover {
+  filter: brightness(160%);
+}
+
+.enter-screen button.skip-intro svg {
+  top: 0.125em;
+  position: relative;
+}
+
+.enter-screen .password {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 60%;
+  text-align: center;
+  filter: brightness(40%) sepia(100%) hue-rotate(-45deg);
+}
+
+.enter-screen .password input {
+  font-size: 0.9rem;
+  padding: 0.4rem;
+  text-align: center;
+}
+
+.enter-screen .password p {
+  margin-top: 1rem;
+}
+
+.enter-screen .password p b {
+  font-size: 1.5rem;
+  line-height: 50px;
+}
+
+.zizi-sidebar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  display: flex;
+  color: #ff9c84;
+  transition: left 1s ease;
+}
+
+.zizi-sidebar.closed {
+  left: -27rem;
+}
+
+.zizi-sidebar .zizi-icon:hover {
+  color: #b22d3f;
+}
+
+.button-sidebar {
+  background-color: #380011;
+  /* padding: 1rem; */
+  box-shadow: 0px 0px 41px 10px rgba(0, 0, 0, 0.7);
+}
+
+.button-sidebar {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  z-index: 1;
+}
+
+.button-sidebar .zizi-icon {
+  font-size: 2.1rem;
+  height: 2rem;
+}
+
+.button-sidebar .close-button,
+.close-sidebar-left .close-button {
+  height: 2rem;
+  width: 2rem;
+  font-size: 2.1rem;
+  padding: 1rem;
+  display: block;
+  background-color: #520319;
+}
+
+.button-sidebar .centered-buttons {
+  display: flex;
+  flex-direction: column;
+}
+
+.button-sidebar .centered-buttons .zizi-icon {
+  padding: 20px 1rem 20px 1rem;
+}
+
+.close-sidebar-left {
+  box-shadow: 0px 0px 41px 10px rgba(0, 0, 0, 0.7);
+  background-color: #380011;
+  width: 1rem;
+  /* font-size: 2.1rem; */
+  z-index: 1;
+}
+
+.main-sidebar {
+  width: 27rem;
+  text-align: center;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  background-color: #2e010f;
+  background: linear-gradient(
+    0deg,
+    rgba(7, 0, 2, 1) 2%,
+    rgba(46, 1, 15, 0.5) 70%,
+    rgba(46, 1, 15, 0.9) 100%
+  );
+  /* transform: translateY(-50%); */
+  z-index: 1;
+}
+
+.main-sidebar .main-bar-content {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.main-sidebar .main-bar-content div.copyright {
+  padding-bottom: 5rem;
+}
+
+.main-sidebar .zizi-icon {
+  font-size: 2rem;
+  -webkit-filter: drop-shadow(0px 0px 10px #000);
+  filter: drop-shadow(0px 0px 10px #000);
+}
+
+.main-sidebar a.inline-link {
+  text-decoration: none;
+  color: #ffbcaf;
+}
+
+.main-sidebar a.inline-link:hover {
+  color: #d63a00;
+}
+
+.main-sidebar #main-bar-logo-bottom {
+  display: none;
+}
+
+.main-sidebar div.divider {
+  width: 6rem;
+  height: 1px;
+  background-color: #ffbcaf;
+  display: block;
+  margin: 1rem auto 1rem auto;
+  height: 1px;
+  flex-shrink: 0;
+}
+
+.main-sidebar .player-controls span {
+  margin: 0 1rem 0 1rem;
+}
+
+.main-sidebar .now-playing .credits,
+.main-sidebar .copyright {
+  font-size: smaller;
+}
+
+.main-sidebar .now-playing .song-title {
+  font-size: 1.1rem;
+}
+
+.main-sidebar .main-bar-content .about-button {
+  font-size: 2rem;
+}
+
+.secondary-sidebar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 30rem;
+  height: 100%;
+  background-color: #2e010f;
+  background: linear-gradient(
+    0deg,
+    rgba(7, 0, 2, 1) 2%,
+    rgba(46, 1, 15, 0.5) 70%,
+    rgba(46, 1, 15, 0.9) 100%
+  );
+  /* background: linear-gradient( 0deg, rgba(7, 0, 2, 1) 2%, rgba(46, 1, 15, 1) 70%, rgba(46, 1, 15, 1) 100%); */
+  color: #ff9c84;
+  text-align: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  transition: right 1s ease;
+  z-index: 2;
+}
+
+.secondary-sidebar.closed {
+  right: -30rem;
+}
+
+.secondary-sidebar .content-sidebar {
+  overflow-x: hidden;
+  overflow-y: scroll;
+  width: 100%;
+}
+
+.performers-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  font-size: 1.2rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.performers-list .performer {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 0.8rem;
+}
+
+.performers-list .performer img {
+  height: 10rem;
+  box-shadow: 4px 4px 10px 1px rgba(0, 0, 0, 0.5);
+  margin: 0.4rem;
+}
+
+.performers-list .performer img:hover {
+  filter: sepia(100%);
+  /* filter: contrast(90%) brightness(123%) blur(2px); */
+  /* https://developer.mozilla.org/en-US/docs/Web/CSS/filter */
+}
+
+.performers-list .pick-performer .name {
+  padding-top: 0.35rem;
+  padding-bottom: 0.7rem;
+}
+
+.performers-list button:hover {
+  color: #ffe6d2;
+}
+
+.performers-list button.info {
+  font-size: 0.9rem;
+  padding-bottom: 0.5rem;
+  color: #a33122;
+}
+
+.performers-list button.info:hover {
+  color: #db2c00;
+}
+
+.bios {
+  text-align: right;
+  padding: 2rem;
+}
+
+.bios h2 {
+  filter: drop-shadow(0px 0px 10px rgb(255, 148, 105))
+    drop-shadow(10px 10px 10px #000) drop-shadow(10px 10px 20px #000);
+}
+
+.bios .backbutton {
+  font-size: 1.2rem;
+  background-color: #520319;
+  padding: 0.5rem;
+  /* border-radius: 12px; */
+  filter: drop-shadow(0px 0px 20px rgba(0, 0, 0, 0.6));
+}
+
+.bios p {
+  text-align: left;
+  font-family: "Roboto Slab", charter, Georgia, Cambria, "Times New Roman",
+    Times, serif;
+}
+
+.bios a {
+  /* padding-top: 5rem; */
+  text-align: center;
+  font-family: "Roboto Slab", charter, Georgia, Cambria, "Times New Roman",
+    Times, serif;
+}
+
+.bios img {
+  width: 100%;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+.secondary-header {
+  margin-top: 2rem;
+}
+
+.secondary-sidebar .song {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  text-align: left;
+  margin-bottom: 1rem;
+  /* background-color: #38001170; */
+}
+
+.secondary-sidebar .song:hover {
+  box-shadow: 0px 0px 50px 5px rgba(0, 0, 0, 0.7);
+}
+
+.secondary-sidebar .song button:hover {
+  color: #f5c5b3;
+}
+
+.secondary-sidebar .song img {
+  height: 4rem;
+  float: left;
+}
+
+.secondary-sidebar .song p {
+  height: 4rem;
+  font-size: 0.95rem;
+  padding-left: 1rem;
+  width: 270px;
+  display: table-cell;
+  vertical-align: middle;
+  -webkit-touch-callout: none;
+}
+
+.secondary-sidebar .song small {
+  color: rgb(180, 95, 74);
+}
+
+.secondary-sidebar .song .sname {
+  color: rgb(255, 225, 200);
+}
+
+/* about page */
 
 .about-page {
   color: #ee9c92;
-  font-family: 'Roboto Slab', charter, Georgia, Cambria, "Times New Roman", Times, serif;
+  font-family: "Roboto Slab", charter, Georgia, Cambria, "Times New Roman",
+    Times, serif;
   line-height: 32px;
   font-size: 18px;
   margin: 0px;
@@ -735,12 +505,13 @@ a:disabled {
   width: 100%;
 }
 
-/* about page */
-
 .about-page h2 {
-  font-family: "market_decoregular", sans-serif;
   margin-top: 4rem;
-  text-align: center;
+}
+
+.about-page p {
+  /* text-align: justify; */
+  /* text-justify: inter-word; */
 }
 
 .about-page .about {
@@ -750,21 +521,12 @@ a:disabled {
   object-fit: fill;
   padding-left: 10rem;
   padding-right: 10rem;
-  overflow: auto;
+  overflow-x: auto;
   overflow-y: scroll;
   height: 100%;
 }
 
-.about-page p {
-  /* text-align: justify; */
-  /* text-justify: inter-word; */
-}
-
 .about-page .secondary-header {
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -o-user-select: none;
   text-align: center;
   display: block;
   margin-left: auto;
@@ -782,17 +544,9 @@ a:disabled {
   mix-blend-mode: lighten;
 }
 
-.about-page .first {
-  margin-top: 0;
-}
-
 .about-page hr {
   border-color: #ee9c92;
   margin: 4rem;
-}
-
-.about-page hr .first {
-  margin-top: 0;
 }
 
 .about-page .footnote {
@@ -801,7 +555,7 @@ a:disabled {
   text-align: left;
 }
 
-.about-page sup {
+.about-page .footnoteLink sup {
   font-size: 12px;
   text-decoration: underline;
 }
@@ -821,15 +575,215 @@ a:disabled {
 .about-page .anchors {
   /* text-align: center; */
   list-style-type: square;
-  margin-top: 2rem;
-  font-family: "market_decoregular", sans-serif;
   font-size: smaller;
+  margin-top: 2rem;
   color: #edb49f;
+}
+
+.about-page .anchor {
+  font-family: "market_decoregular", sans-serif;
   text-decoration: underline;
+}
+
+.about-page .anchor:hover {
+  color: #aa272e;
 }
 
 .about-page .diagram {
   width: 100%;
   margin: 20px 0 20px 0;
   mix-blend-mode: lighten;
+}
+
+.pickerAboutButton {
+  position: absolute;
+  bottom: 2rem;
+  left: 6rem;
+  font-size: 1.6rem;
+  color: #ff9c84;
+  background-color: rgba(46, 1, 15, 0.5);
+  border-radius: 12px;
+  padding: 0.6rem;
+  filter: drop-shadow(20px 20px 5px #000);
+}
+
+.pickerAboutButton:hover {
+  -webkit-filter: drop-shadow(0px 0px 0px #800a12);
+  filter: drop-shadow(0px 0px 0px #800a12);
+}
+
+.main-sidebar #main-bar-logo-top,
+.main-sidebar #main-bar-logo-bottom {
+  /* -webkit-flex: 1 0;
+  flex: 1 0; */
+  -webkit-flex-shrink: 0;
+  -moz-flex-shrink: 0;
+  -ms-flex: 0;
+  flex-shrink: 0;
+}
+
+.zizi-intro-video {
+  position: absolute;
+  height: 100%;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 0;
+}
+
+.intro-video {
+  position: absolute;
+  height: 100%;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: -2;
+}
+
+#main-bar-logo-top,
+#main-bar-logo-bottom,
+.curtain-bg,
+.curtain-side,
+.drag-video,
+.secondary-header,
+.secondary-sidebar .song img,
+.secondary-sidebar .song p,
+.about-page .secondary-header {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+/* display for mobile and tablet */
+
+@media (max-aspect-ratio: 4/5) and (orientation: portrait) {
+  html {
+    font-size: 14px;
+  }
+
+  .enter-screen button.enter img {
+    height: auto;
+    width: 90%;
+  }
+
+  .enter-screen button.skip-intro {
+    right: 2rem;
+  }
+
+  .zizi-sidebar {
+    right: 0;
+    top: auto;
+    bottom: 0;
+    height: 30rem;
+    flex-direction: column-reverse;
+    transition: bottom 1s ease;
+  }
+
+  .zizi-sidebar.closed {
+    left: 0;
+    bottom: -26rem;
+  }
+
+  .button-sidebar {
+    flex-direction: row;
+    /* height: 20%; */
+    /* height for safari - no idea why */
+  }
+
+  .button-sidebar .centered-buttons {
+    flex-direction: row;
+  }
+
+  .button-sidebar .centered-buttons .zizi-icon {
+    padding: 1rem 20px 1rem 20px;
+  }
+
+  .close-sidebar-left {
+    width: 100%;
+    height: 1rem;
+    min-height: 1rem;
+    max-height: 1rem;
+  }
+
+  .secondary-header {
+    margin-top: 1rem;
+  }
+
+  .main-sidebar {
+    width: 100%;
+  }
+
+  .main-sidebar .main-bar-content {
+    flex-shrink: 0;
+    margin-top: 2rem;
+  }
+
+  .secondary-sidebar {
+    left: 0;
+    top: auto;
+    bottom: 0;
+    width: 100%;
+    height: 30rem;
+    flex-direction: column;
+    transition: bottom 1s ease;
+    /* background: linear-gradient( 0deg, rgba(7, 0, 2, 1) 2%, rgba(46, 1, 15, 1) 70%, rgba(46, 1, 15, 1) 100%); */
+    backdrop-filter: blur(2px);
+  }
+
+  .secondary-sidebar.closed {
+    bottom: -35rem;
+  }
+
+  .secondary-sidebar.zizi-picker-bar {
+    background: linear-gradient(
+      0deg,
+      rgba(7, 0, 2, 1) 2%,
+      rgba(46, 1, 15, 0.5) 70%,
+      rgba(46, 1, 15, 0.9) 100%
+    );
+    backdrop-filter: none;
+  }
+
+  .main-sidebar #main-bar-logo-top {
+    display: none;
+  }
+
+  .main-sidebar #main-bar-logo-bottom {
+    display: block;
+    height: 8rem;
+  }
+
+  .main-sidebar .main-bar-content div.copyright {
+    padding-bottom: 1rem;
+  }
+
+  .about-page .about {
+    padding: 1.5rem;
+  }
+
+  .about-page p {
+    font-size: 1.1rem;
+  }
+  .about-page .anchors {
+    padding: 0.5rem;
+  }
+
+  .pickerAboutButton {
+    top: 2rem;
+    left: 1rem;
+    height: 3rem;
+  }
+}
+
+@media only screen and (min-device-width: 320px) and (max-device-width: 568px) and (orientation: landscape) {
+  body #main-bar-logo-top {
+    /* order: 1; */
+    height: 12rem;
+    /* flex-shrink: 0; */
+  }
+
+  body .main-sidebar {
+    display: block;
+  }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -87,7 +87,7 @@ export default class App extends React.Component {
 }
 
 window.addEventListener('orientationchange', function() {
-  if (window.orientation == 0 || window.orientation == 180) {
+  if (window.orientation === 0 || window.orientation === 180) {
       // Reset scroll position if in portrait mode.
       // window.scrollTo({ top: 0 });
       // this.bar.current.scrollTo({ top: 30 });

--- a/src/Buttons.js
+++ b/src/Buttons.js
@@ -18,39 +18,39 @@ import {
 
 function Play(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <PlayArrowRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function Pause(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <PauseRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function ZoomOut(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <ZoomOutRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function ZoomIn(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <ZoomInRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function ShowPerformers(props) {
   return (
-    <a className="zizi-icon" fontSize="inherit" onClick={props.onClick}>
+    <span className="zizi-icon" fontSize="inherit" onClick={props.onClick}>
       <svg
         className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
         focusable="false"
@@ -59,13 +59,13 @@ function ShowPerformers(props) {
       >
         <path d="M4,13c1.1,0,2-0.9,2-2c0-1.1-0.9-2-2-2s-2,0.9-2,2C2,12.1,2.9,13,4,13z M5.13,14.1C4.76,14.04,4.39,14,4,14 c-0.99,0-1.93,0.21-2.78,0.58C0.48,14.9,0,15.62,0,16.43V18l4.5,0v-1.61C4.5,15.56,4.73,14.78,5.13,14.1z M20,13c1.1,0,2-0.9,2-2 c0-1.1-0.9-2-2-2s-2,0.9-2,2C18,12.1,18.9,13,20,13z M24,16.43c0-0.81-0.48-1.53-1.22-1.85C21.93,14.21,20.99,14,20,14 c-0.39,0-0.76,0.04-1.13,0.1c0.4,0.68,0.63,1.46,0.63,2.29V18l4.5,0V16.43z M16.24,13.65c-1.17-0.52-2.61-0.9-4.24-0.9 c-1.63,0-3.07,0.39-4.24,0.9C6.68,14.13,6,15.21,6,16.39V18h12v-1.61C18,15.21,17.32,14.13,16.24,13.65z M8.07,16 c0.09-0.23,0.13-0.39,0.91-0.69c0.97-0.38,1.99-0.56,3.02-0.56s2.05,0.18,3.02,0.56c0.77,0.3,0.81,0.46,0.91,0.69H8.07z M12,8 c0.55,0,1,0.45,1,1s-0.45,1-1,1s-1-0.45-1-1S11.45,8,12,8 M12,6c-1.66,0-3,1.34-3,3c0,1.66,1.34,3,3,3s3-1.34,3-3 C15,7.34,13.66,6,12,6L12,6z" />
       </svg>
-    </a>
+    </span>
   );
 }
 
 function NewPerformer(props) {
   return (
-    <a className="zizi-icon" onClick={props.onClick}>
+    <span className="zizi-icon" onClick={props.onClick}>
       <svg
         className="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit"
         focusable="false"
@@ -76,79 +76,79 @@ function NewPerformer(props) {
           <path d="M16.487 12a2.248 2.248 0 10.001-4.497A2.248 2.248 0 0016.487 12zm0 1.125c-1.501 0-4.499.754-4.499 2.249v.562c0 .309.253.562.562.562h7.872a.564.564 0 00.562-.562v-.562c.002-1.496-2.995-2.249-4.497-2.249zm-10.254-.859a5.674 5.674 0 01-.622.81c-.557.586-1.285.742-2.069.702-.705-.036-.701 1.057 0 1.093 1.474.075 2.516-.562 3.346-1.647a9.412 9.412 0 01-.378-.53 16.245 16.245 0 01-.277-.428zm1.423-.87l.226.351c.138-.191.286-.375.452-.547.419-.433.897-.61 1.421-.661l-.099.121c-.192.228-.224.549 0 .773.197.197.581.228.773 0 .296-.351.578-.713.873-1.065.192-.193.266-.515.028-.773l-.984-1.065c-.479-.519-1.25.256-.773.773l.128.138c-.536.038-1.053.175-1.53.485a4.1 4.1 0 00-.923.855c.054.075.107.152.16.232.085.127.168.257.248.383zm2.772 1.171a.473.473 0 00-.369-.16.58.58 0 00-.404.16c-.224.224-.192.545 0 .773l.099.121c-.524-.05-1.002-.228-1.421-.661a5.613 5.613 0 01-.628-.8c-.183-.273-.354-.554-.536-.829a5.951 5.951 0 00-.106-.154c-.815-1.169-1.834-1.894-3.29-1.894a4.55 4.55 0 00-.232.006c-.69.035-.704 1.093-.034 1.093l.034-.001a4.28 4.28 0 01.225-.006c.698 0 1.34.178 1.844.708.31.327.555.7.794 1.077.113.179.226.358.344.535.101.151.206.302.316.449.313.418.668.805 1.108 1.091.477.31.993.446 1.53.485l-.128.138c-.366.396.002.944.41.944a.489.489 0 00.363-.172l.983-1.065c.238-.258.165-.58-.028-.773-.296-.352-.578-.714-.874-1.065z" />
         </g>
       </svg>
-    </a>
+    </span>
   );
 }
 
 function Captions(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <ClosedCaptionRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function Fullscreen(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <FullscreenRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function ShowSongs(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <ListRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function Close(props) {
   return (
-    <a className="zizi-icon close">
+    <span className="zizi-icon close">
       <CloseRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function Menu(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <MenuRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function Forward10(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <Forward10Rounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function Back10(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <Replay10Rounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function SkipToNextTrack(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <SkipNextRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 
 function Return(props) {
   return (
-    <a className="zizi-icon">
+    <span className="zizi-icon">
       <KeyboardReturnRounded fontSize="inherit" onClick={props.onClick} />
-    </a>
+    </span>
   );
 }
 

--- a/src/Curtain.js
+++ b/src/Curtain.js
@@ -5,7 +5,7 @@ export default function Curtain(props) {
   let srcBg = "img/curtain-bg-" + zoomString + ".jpg";
   let srcSide = "img/curtain-side-" + zoomString + ".png";
   return [
-      <img key="one" src={srcBg} className="curtain-bg " draggable={false} />,
-      <img key="two" src={srcSide} className="curtain-side" draggable={false} />
+      <img key="one" src={srcBg} className="curtain-bg " draggable={false} alt="" />,
+      <img key="two" src={srcSide} className="curtain-side" draggable={false} alt="" />
   ];
 }

--- a/src/IntroScreen.js
+++ b/src/IntroScreen.js
@@ -29,7 +29,7 @@ export default class IntroScreen extends React.Component {
     if (this.state.entered) {
       return (
         <div className="enter-screen">
-          
+
           <video
             className="zizi-intro-video"
             onEnded={this.props.onEnter}
@@ -39,7 +39,7 @@ export default class IntroScreen extends React.Component {
           >
           <source src="https://s3-eu-west-1.amazonaws.com/zizi.ai/vid/intro-and-host/intro/playlist.m3u8" />
           </video>
-          <button onClick={this.props.onEnter}>
+          <button className="skip-intro" onClick={this.props.onEnter}>
             Skip Intro <FastForwardRounded fontSize="inherit" />
           </button>
         </div>
@@ -48,12 +48,12 @@ export default class IntroScreen extends React.Component {
 
     return (
       <div className="enter-screen">
-        <a className="enter" onClick={this.attemptLogin}>
-          <img src="img/enterButton.png" />
-        </a>
-        <form onSubmit={this.attemptLogin}>
+        <button type="button" className="enter" onClick={this.attemptLogin}>
+          <img src="img/enterButton.png" alt="Enter the Zizi show" />
+        </button>
+        <form className="password" onSubmit={this.attemptLogin}>
           <input
-            className="password"
+
             type="password"
             name="password"
             value={this.state.password}
@@ -61,8 +61,8 @@ export default class IntroScreen extends React.Component {
             placeholder="Password"
 
           />
+          <p><b>BETA version</b><br></br>Works best in Chrome (desktop). <br></br>Known bugs on mobile.</p>
         </form>
-        <p className="password"><b>BETA version</b><br></br>Works best in Chrome (desktop). <br></br>Known bugs on mobile.</p>
 
         <Curtain />
       </div>

--- a/src/ShowData.js
+++ b/src/ShowData.js
@@ -123,7 +123,7 @@ let performers = {
     id: "lilly",
     name: "Lilly SnatchDragon",
     insta: "lillysnatch",
-    bio: ["Lilly SnatchDragon is an international, award - winning drag queen, burlesque artist and compere. Her approach to how the West stereotypes S.E Asian women won her 'Best Newcomer' at the London Cabaret Awards in 2015.  She has been in the Top 15 ‘UK Burlesque Performers’ since 2015, including No. 1 in 2017 and No. 3 in 2018.  Lilly is currently #5 in the world and #5 in the UK for 2019. She is also one of the founders of sell-out show ‘LADS’ and of renowned all-Asian cabaret collective ‘The Bitten Peach’. ",<a className="instagram" target='_blank' href='https://www.instagram.com/bittenpeachuk'>@bittenpeachuk</a>],
+    bio: ["Lilly SnatchDragon is an international, award - winning drag queen, burlesque artist and compere. Her approach to how the West stereotypes S.E Asian women won her 'Best Newcomer' at the London Cabaret Awards in 2015.  She has been in the Top 15 ‘UK Burlesque Performers’ since 2015, including No. 1 in 2017 and No. 3 in 2018.  Lilly is currently #5 in the world and #5 in the UK for 2019. She is also one of the founders of sell-out show ‘LADS’ and of renowned all-Asian cabaret collective ‘The Bitten Peach’. ",<a className="instagram" target='_blank' rel="noopener noreferrer" href='https://www.instagram.com/bittenpeachuk'>@bittenpeachuk</a>],
     n: 5
   },
   luke: {
@@ -144,7 +144,7 @@ let performers = {
     id: "mark",
     name: "Mark Anthony",
     insta: "markanthony.dragking",
-    bio: ["Mark has been performing in the UK and internationally for nearly four years and is the current Mr Boylesque UK. A man on a mission to challenge the status quo, he is the first Drag King and trans performer to hold the Mr Boylesque title worldwide and to win renowned Not Another Drag Competition. Known for smooth vocals, comical lip-syncs, sexy strips and occasionally a cello, this king can pull almost anything out of his rhinestoned utility belt. ", <a target='_blank' href='https://www.youtube.com/channel/UCX78ZNHPZg-PbAfjDKZ1mGA?view_as=subscriber'>Youtube</a>],
+    bio: ["Mark has been performing in the UK and internationally for nearly four years and is the current Mr Boylesque UK. A man on a mission to challenge the status quo, he is the first Drag King and trans performer to hold the Mr Boylesque title worldwide and to win renowned Not Another Drag Competition. Known for smooth vocals, comical lip-syncs, sexy strips and occasionally a cello, this king can pull almost anything out of his rhinestoned utility belt. ", <a target='_blank' rel="noopener noreferrer" href='https://www.youtube.com/channel/UCX78ZNHPZg-PbAfjDKZ1mGA?view_as=subscriber'>Youtube</a>],
     n: 8
   },
   me: {

--- a/src/sidebar/Performers.js
+++ b/src/sidebar/Performers.js
@@ -35,17 +35,15 @@ export default class Performers extends React.PureComponent {
   renderPerformer(performer) {
     return (
       <div className="performer" key={performer.id}>
-        <a onClick={() => this.props.changePerformer(performer.id)}>
+        <button type="button" className="pick-performer" onClick={() => this.props.changePerformer(performer.id)}>
           <img
-            alt={`Image of '${performer.name}'`}
+            alt={performer.name}
             src={`img/performers/PickerImage/${performer.id}.jpg`}
             draggable="false"
           />
-          <p>{performer.name}</p>
-        </a>
-        <p className="info">
-          <a onClick={() => this.props.showAboutView(performer.id)}>About</a>
-        </p>
+          <div class="name">{performer.name}</div>
+        </button>
+        <button type="button" className="info" onClick={() => this.props.showAboutView(performer.id)}>About</button>
       </div>
     );
   }
@@ -53,15 +51,15 @@ export default class Performers extends React.PureComponent {
   renderAboutView(performer) {
     return (
       <div className="bios">
-        <a className="backbutton" onClick={this.props.showThumbnails}>Back</a>
+        <button type="button" className="backbutton" onClick={this.props.showThumbnails}>Back</button>
         <h2>{performer.name}</h2>
 
         <img
-          alt={`Image of '${performer.name}'`}
+          alt={performer.name}
           src={`img/performers/BioImage/${performer.id}.jpg`}
           draggable="false"
         />
-        <a className="instagram" target='_blank' href={'https://www.instagram.com/' + performer.insta}>@{performer.insta}</a>
+        <a className="instagram" target='_blank' rel="noopener noreferrer" href={'https://www.instagram.com/' + performer.insta}>@{performer.insta}</a>
         <p>{performer.bio}</p>
       </div>
     );

--- a/src/sidebar/SecondaryBar.js
+++ b/src/sidebar/SecondaryBar.js
@@ -6,7 +6,7 @@ export default function (props) {
   let classes = ["secondary-sidebar", props.className, secondaryBarOpenClose];
 
   let maybeCloseButton = props.onClose == null ? null : (
-    <div className="close-button2">
+    <div className="close-button">
       <Close onClick={props.onClose} />
     </div>
   );

--- a/src/sidebar/Songs.js
+++ b/src/sidebar/Songs.js
@@ -11,7 +11,7 @@ export default class Songs extends React.PureComponent {
 
     return (
       <div>
-        <img src="img/pick.png" className="secondary-header" draggable="false" />
+        <img src="img/pick.png" className="secondary-header" draggable="false" alt="Pick an act" />
         <div className="songs-list">{renderedSongs}</div>
       </div>
     );
@@ -20,14 +20,14 @@ export default class Songs extends React.PureComponent {
   renderSong(song) {
     return (
       <div className="song" key={song.id}>
-        <a onClick={() => this.props.changeSong(song.id)}>
-            <img src={`img/album_covers/${song.id}.jpg`} draggable="false" />
+        <button type="button" onClick={() => this.props.changeSong(song.id)}>
+            <img src={`img/album_covers/${song.id}.jpg`} draggable="false" alt="song" />
             <p>
             <span className="sname">{song.name}</span> | {song.artist} <br />
             <small>Movement by <b><span>{this.props.performers[song.performer].name}</span></b></small>
           </p>
-        </a>
+        </button>
       </div>
     );
   }
-} 
+}

--- a/src/sidebar/ZiziSidebar.js
+++ b/src/sidebar/ZiziSidebar.js
@@ -20,7 +20,7 @@ import SecondaryBar from "./SecondaryBar";
 export default class ZiziSidebar extends React.Component {
   constructor(props) {
     super(props);
-    this.bar = React.createRef()
+    this.bar = React.createRef();
     this.state = {
       fullSize: false,
       showSecondaryBar: false,
@@ -47,17 +47,17 @@ export default class ZiziSidebar extends React.Component {
     let zoomInOut = this.props.zoom ? (
       <ZoomOut onClick={this.props.onZoomOut} />
     ) : (
-        <ZoomIn onClick={this.props.onZoomIn} />
-      );
+      <ZoomIn onClick={this.props.onZoomIn} />
+    );
 
     let hideShow = this.state.fullSize ? (
       <Close onClick={this.hideMain} />
     ) : (
-        <Menu onClick={this.showMain} />
-      );
+      <Menu onClick={this.showMain} />
+    );
 
     return (
-      <div className="mini-sidebar button-sidebar">
+      <div className="button-sidebar">
         <div className="close-button">{hideShow}</div>
         <div className="centered-buttons">
           {zoomInOut}
@@ -70,66 +70,96 @@ export default class ZiziSidebar extends React.Component {
     );
   }
 
+  inlineLink(handleClick, text) {
+    return (
+      <button type="button" className="inline-link" onClick={handleClick}>
+        {text}
+      </button>
+    );
+  }
+
+
   renderMainbar() {
     let playPause = this.props.playing ? (
       <Pause onClick={this.props.onPause} />
     ) : (
-        <Play onClick={this.props.onPlay} />
-      );
+      <Play onClick={this.props.onPlay} />
+    );
 
-    let movementPerformer = this.props.showData.performers[this.props.song.performer];
+    let movementPerformer = this.props.showData.performers[
+      this.props.song.performer
+    ];
     let bodyPerformer = this.props.performer;
 
     return (
       <div className="main-sidebar" ref={this.bar}>
-        <img
-          src="img/title.png"
-          id="main-bar-logo"
-          alt="The Zizi Show"
-          draggable="false"
-        />
         <div className="main-bar-content">
+          <img
+            src="img/title.png"
+            id="main-bar-logo-top"
+            alt="The Zizi Show"
+            draggable="false"
+          />
           <div className="player-controls">
             {playPause}
             <Back10 onClick={this.props.onBack10} />
             <Forward10 onClick={this.props.onForward10} />
             <Fullscreen />
           </div>
+          <div className="divider"></div>
           <div className="now-playing">
-            <p>{`"${this.props.song.name}" by ${this.props.song.artist}`}</p>
-            <sub>
-              Movement by <a className="inline-link" onClick={() => this.showAboutView(movementPerformer.id)}>
-                {movementPerformer.name}
-              </a>
-            </sub>
-            <sub>
-              Deepfake trained on <a className="inline-link" onClick={() => this.showAboutView(bodyPerformer.id)}>
-                {bodyPerformer.name}
-              </a>
-            </sub>
+            <div className="song-title">
+              {this.props.song.name} by {this.props.song.artist}
+            </div>
+            <div className="credits">
+              Movement by{" "}
+              {this.inlineLink(
+                () => this.showAboutView(movementPerformer.id),
+                movementPerformer.name
+              )}
+            </div>
+            <div className="credits">
+              Deepfake trained on{" "}
+              {this.inlineLink(
+                () => this.showAboutView(bodyPerformer.id),
+                bodyPerformer.name
+              )}
+            </div>
           </div>
+          <div className="divider"></div>
+
           <div className="about-button">
-            <a onClick={this.showAbout} className="sidebar-large-button">
-              ABOUT
-            </a>
+          <button type="button" className="about-button" onClick={this.showAbout}>
+            ABOUT
+          </button>
           </div>
-        </div>
-        <div className="copyright">
-          <sub>The Zizi Project&copy;</sub>
-          <sub>
-            <a className="inline-link" href="https://jakeelwes.com">
-              Jake Elwes</a> 2020
-          </sub>
-          <sub>
-            Part of <a className="inline-link" href="https://newreal.cc">
-              newreal.cc
-            </a>
-          </sub>
-          <sub>
-            {/* <a className="inline-link" href="https://instagram.com/zizidrag">
-              Instagram
-            </a> */}
-          </sub>
+          <div className="divider"></div>
+          <div className="copyright">
+            <img
+              src="img/title.png"
+              id="main-bar-logo-bottom"
+              alt="The Zizi Show"
+              draggable="false"
+            />
+            <div>The Zizi Project&copy;</div>
+            <div>
+              <a className="inline-link" href="https://jakeelwes.com">
+                Jake Elwes
+              </a>{" "}
+              2020
+            </div>
+            <div>
+              Part of{" "}
+              <a className="inline-link" href="https://newreal.cc">
+                newreal.cc
+              </a>
+            </div>
+            <div>
+              {/* <a className="inline-link" href="https://instagram.com/zizidrag">
+                      Instagram
+                      </a> */}
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -137,7 +167,10 @@ export default class ZiziSidebar extends React.Component {
 
   renderSecondaryBar() {
     return (
-      <SecondaryBar onClose={this.hideSecondaryBar} openClose={this.state.showSecondaryBar}>
+      <SecondaryBar
+        onClose={this.hideSecondaryBar}
+        openClose={this.state.showSecondaryBar}
+      >
         {this.renderSecondaryBarContent()}
       </SecondaryBar>
     );
@@ -184,7 +217,7 @@ export default class ZiziSidebar extends React.Component {
       // performer: this.props.showData.performers[performerName],
       showSecondaryBar: false,
     });
-    this.props.changePerformer(performer)
+    this.props.changePerformer(performer);
   };
 
   showPerformers = () => {
@@ -192,7 +225,6 @@ export default class ZiziSidebar extends React.Component {
       secondaryBar: { type: "performers", content: "thumbnails" },
       showSecondaryBar: !this.state.showSecondaryBar,
     });
-
   };
 
   showAbout = () => {


### PR DESCRIPTION
PR raised with following changes:

- Fixed the lint warnings in the existing code:
   - The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid
   - Using target="_blank" without rel="noopener noreferrer" is a security risk: see https://mathiasbynens.github.io/rel-noopener  react/jsx-no-target-blank
   - img elements must have an alt prop, either with meaningful text, or an empty string for decorative images jsx-a11y/alt-text
   - Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop jsx-a11y/img-redundant-alt
   - Anchors must have content and the content must be accessible by a screen reader jsx-a11y/anchor-has-content
   - <iframe> elements must have a unique title property jsx-a11y/iframe-has-title
   - Expected '===' and instead saw '=='  eqeqeq
- Modified the css to use buttons and spans as appropriate instead of anchors for internal navigation.
- Moved the media override to the bottom of the file: css style overrides use the last declared version of a selector. By having the override at the bottom, and ensuring the css selectors are exactly the same between main definition and media query based override, its a safer way of overriding when needed than having to add extra selection criteria (.body) to each clause.
- Restructured a few of the flex structures to simplify them - fixes the icons overlaying the logo on the sidebar for one.
- Added and used class names to clarify which styles applied where in the DOM.
- Added 'width:200%' to '.drag-video' to fix the safari issue where making the window wide and short makes the video move off to the right. What appeared to be happening is that .drag-video seemed to be growing wider, and taking the video centered within it out of the visible area. Fixing .drag-video to the size of the video image seems to work.
